### PR TITLE
Fix GetCPUOverCommitPercent()

### DIFF
--- a/server/pkg/lxdclient/resource.go
+++ b/server/pkg/lxdclient/resource.go
@@ -23,7 +23,7 @@ type Resource struct {
 
 // GetCPUOverCommitPercent calculate percent of over commit
 func GetCPUOverCommitPercent(in Resource) uint64 {
-	return (in.CPUUsed / in.CPUTotal) * 100
+	return uint64(float64(in.CPUUsed) / float64(in.CPUTotal) * 100.0)
 }
 
 // GetResource get Resource


### PR DESCRIPTION
GetCPUOverCommitPercent() always returns x00 ,because `in.CPUUsed` and `in.CPUTotal` are uint64 and `in.CPUUsed / in.CPUTotal` returns integer.
This PR fix this function and returns correct percentage (e.g. 157 or 189 or so...).