### PR TITLE
Clear instance source server in pool-agent config

### DIFF
--- a/pool-agent/cmd/agent.go
+++ b/pool-agent/cmd/agent.go
@@ -216,7 +216,7 @@ func (a *Agent) adjustInstancePool() error {
 	}
 
 	for _, i := range s {
-		if i.Config[configKeyResourceType] == "" || i.Config[configKeyImageAlias] == "" || i.Config[configKeyRunnerName] == "" {
+		if i.Config[configKeyResourceType] == "" || i.Config[configKeyImageAlias] == "" {
 			continue
 		}
 		l := slog.With("instance", i.Name)

--- a/pool-agent/cmd/agent.go
+++ b/pool-agent/cmd/agent.go
@@ -52,6 +52,8 @@ func newAgent(ctx context.Context) (*Agent, error) {
 	if err != nil {
 		return nil, err
 	}
+	source.Server = ""
+
 	c, err := lxd.ConnectLXDUnixWithContext(ctx, "", &lxd.ConnectionArgs{})
 	if err != nil {
 		return nil, fmt.Errorf("connect lxd: %w", err)
@@ -110,6 +112,7 @@ func (a *Agent) reloadConfig() error {
 			return fmt.Errorf("parse image alias: %w", err)
 		}
 		a.InstanceSource = *source
+		a.InstanceSource.Server = ""
 		a.ImageAlias = conf.ImageAlias
 	}
 	a.ResourceTypesMap = conf.ResourceTypesMap


### PR DESCRIPTION
This pull request includes changes to the `pool-agent/cmd/agent.go` file to ensure that the `Server` field of the `InstanceSource` struct is properly reset. The most important changes are:

* [`pool-agent/cmd/agent.go`](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dR55-R56): Added a line to set `source.Server` to an empty string in the `newAgent` function to ensure the `Server` field is reset when creating a new agent.
* [`pool-agent/cmd/agent.go`](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dR115): Added a line to set `a.InstanceSource.Server` to an empty string in the `reloadConfig` method to ensure the `Server` field is reset when reloading the configuration.

---
This change will be resolved the following issue:
- When the remote server managing images becomes unavailable or stops functioning correctly, it is not possible to create new runners.
    - With this update, local images are always referenced, ensuring the system is no longer impacted by remote image server failures.