### PR TITLE
fix pool agent reload config

### DIFF
--- a/pool-agent/cmd/agent.go
+++ b/pool-agent/cmd/agent.go
@@ -131,11 +131,9 @@ func (a *Agent) reloadConfig() error {
 				return err
 			}
 			s.Server = ""
-			a.Config[version] = &AgentConfig{
-				ImageAlias:          conf.ImageAlias,
-				InstanceSource:      *s,
-				ResourceTypesCounts: conf.ResourceTypesCounts,
-			}
+			a.Config[version].ImageAlias = conf.ImageAlias
+			a.Config[version].InstanceSource = *s
+			a.Config[version].ResourceTypesCounts = conf.ResourceTypesCounts
 		}
 	}
 	a.ResourceTypesMap = confmap.ResourceTypesMap


### PR DESCRIPTION
## Summary

After reload config, caused panic on create new container.

## Background

In `newAgent()` , all config properties are assigned.
https://github.com/whywaita/shoes-lxd-multi/blob/e74f6b07ae2d09557d96841ca0fd9dfa74fae434/pool-agent/cmd/agent.go#L64-L69

But in `reloadConfig()`, assigned properties are not enough.
https://github.com/whywaita/shoes-lxd-multi/blob/e74f6b07ae2d09557d96841ca0fd9dfa74fae434/pool-agent/cmd/agent.go#L134-L138

This agent references they often, so caused panic.

## Generated
This pull request includes a modification to the `reloadConfig` method in the `pool-agent/cmd/agent.go` file. The change involves updating the way the `AgentConfig` is assigned to avoid creating a new instance and instead updating the existing configuration.

Configuration update:

* [`pool-agent/cmd/agent.go`](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dL134-R136): Modified the `reloadConfig` method to update the existing `AgentConfig` instead of creating a new instance. This change ensures that only the necessary fields are updated, improving efficiency and reducing potential errors.