### PR TITLE
add labels to pool agent metrics

### DIFF
--- a/pool-agent/cmd/agent.go
+++ b/pool-agent/cmd/agent.go
@@ -329,7 +329,7 @@ func (a *Agent) collectMetrics() error {
 	}
 	lxdInstances.Reset()
 	for _, i := range s {
-		lxdInstances.WithLabelValues(i.Status, i.Config[configKeyResourceType], i.Config[configKeyImageAlias]).Inc()
+		lxdInstances.WithLabelValues(i.Status, i.Config[configKeyResourceType], i.Config[configKeyImageAlias], i.Name, i.Config[configKeyRunnerName]).Inc()
 	}
 	return nil
 }

--- a/pool-agent/cmd/metrics.go
+++ b/pool-agent/cmd/metrics.go
@@ -21,6 +21,6 @@ var (
 			Subsystem: "lxd",
 			Namespace: "pool_agent",
 		},
-		[]string{"status", "flavor", "image_alias"},
+		[]string{"status", "flavor", "image_alias", "container_name", "runner_name"},
 	)
 )


### PR DESCRIPTION
These labels are provided to:
- linking container name and runner name
- filtering allocated or not container

## Summary (generated)

This pull request includes updates to the `pool-agent` to enhance the collection of metrics by adding new labels to the `lxdInstances` metric.

Changes to metrics collection:

* [`pool-agent/cmd/agent.go`](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dL332-R332): Updated the `collectMetrics` function to include `i.Name` and `i.Config[configKeyRunnerName]` in the `lxdInstances` metric labels.
* [`pool-agent/cmd/metrics.go`](diffhunk://#diff-88863f11731917e814622a55c0e654dd94b2843560987f519fe65923f71db89cL24-R24): Modified the `lxdInstances` metric definition to add `container_name` and `runner_name` to the list of labels.