### PR TITLE
Reset context after WithContext

### DIFF
--- a/server/pkg/api/pool.go
+++ b/server/pkg/api/pool.go
@@ -24,7 +24,7 @@ type gotInstances struct {
 	Error             error
 }
 
-func getInstancesWithTimeout(_ctx context.Context, h lxdclient.LXDHost, d time.Duration, l *slog.Logger) ([]api.Instance, uint64, error) {
+func getInstancesWithTimeout(_ctx context.Context, h *lxdclient.LXDHost, d time.Duration, l *slog.Logger) ([]api.Instance, uint64, error) {
 	ret := make(chan *gotInstances)
 	ctx, cancel := context.WithTimeout(_ctx, d)
 	defer cancel()
@@ -82,7 +82,7 @@ type instance struct {
 	InstanceName string
 }
 
-func findInstances(ctx context.Context, targets []lxdclient.LXDHost, match func(api.Instance) bool, limitOverCommit uint64, l *slog.Logger) []instance {
+func findInstances(ctx context.Context, targets []*lxdclient.LXDHost, match func(api.Instance) bool, limitOverCommit uint64, l *slog.Logger) []instance {
 	type result struct {
 		host              *lxdclient.LXDHost
 		overCommitPercent uint64
@@ -94,7 +94,7 @@ func findInstances(ctx context.Context, targets []lxdclient.LXDHost, match func(
 	for i, target := range targets {
 		wg.Add(1)
 		l := l.With("host", target.HostConfig.LxdHost)
-		go func(i int, target lxdclient.LXDHost) {
+		go func(i int, target *lxdclient.LXDHost) {
 			defer wg.Done()
 
 			s, overCommitPercent, err := getInstancesWithTimeout(ctx, target, 10*time.Second, l)
@@ -120,7 +120,7 @@ func findInstances(ctx context.Context, targets []lxdclient.LXDHost, match func(
 			})
 
 			rs[i] = result{
-				host:              &target,
+				host:              target,
 				overCommitPercent: overCommitPercent,
 				instances:         instances,
 			}
@@ -145,7 +145,7 @@ func findInstances(ctx context.Context, targets []lxdclient.LXDHost, match func(
 	return instances
 }
 
-func findInstanceByJob(ctx context.Context, targets []lxdclient.LXDHost, runnerName string, l *slog.Logger) (*lxdclient.LXDHost, string, bool) {
+func findInstanceByJob(ctx context.Context, targets []*lxdclient.LXDHost, runnerName string, l *slog.Logger) (*lxdclient.LXDHost, string, bool) {
 	s := findInstances(ctx, targets, func(i api.Instance) bool {
 		return i.Config[lxdclient.ConfigKeyRunnerName] == runnerName && i.StatusCode == api.Frozen
 	}, 0, l)
@@ -155,7 +155,7 @@ func findInstanceByJob(ctx context.Context, targets []lxdclient.LXDHost, runnerN
 	return s[0].Host, s[0].InstanceName, true
 }
 
-func allocatePooledInstance(ctx context.Context, targets []lxdclient.LXDHost, resourceType, imageAlias string, limitOverCommit uint64, runnerName string, l *slog.Logger) (*lxdclient.LXDHost, string, error) {
+func allocatePooledInstance(ctx context.Context, targets []*lxdclient.LXDHost, resourceType, imageAlias string, limitOverCommit uint64, runnerName string, l *slog.Logger) (*lxdclient.LXDHost, string, error) {
 	s := findInstances(ctx, targets, func(i api.Instance) bool {
 		if i.StatusCode != api.Frozen {
 			return false

--- a/server/pkg/api/pool.go
+++ b/server/pkg/api/pool.go
@@ -187,6 +187,8 @@ func allocatePooledInstance(ctx context.Context, targets []*lxdclient.LXDHost, r
 }
 
 func allocateInstance(host *lxdclient.LXDHost, instanceName, runnerName string, l *slog.Logger) error {
+	host.APICallMutex.Lock()
+	defer host.APICallMutex.Unlock()
 	i, etag, err := host.Client.GetInstance(instanceName)
 	if err != nil {
 		return fmt.Errorf("get instance: %w", err)

--- a/server/pkg/api/server.go
+++ b/server/pkg/api/server.go
@@ -57,7 +57,7 @@ func (s *ShoesLXDMultiServer) Run(listenPort int) error {
 	return nil
 }
 
-func (s *ShoesLXDMultiServer) validateTargetHosts(ctx context.Context, targetHosts []string, logger *slog.Logger) ([]lxdclient.LXDHost, error) {
+func (s *ShoesLXDMultiServer) validateTargetHosts(ctx context.Context, targetHosts []string, logger *slog.Logger) ([]*lxdclient.LXDHost, error) {
 	var hostConfigs []config.HostConfig
 
 	for _, target := range targetHosts {

--- a/server/pkg/api/server_delete_instance.go
+++ b/server/pkg/api/server_delete_instance.go
@@ -33,6 +33,8 @@ func (s *ShoesLXDMultiServer) DeleteInstance(ctx context.Context, req *pb.Delete
 		}
 	}
 
+	l = l.With("host", host.HostConfig.LxdHost)
+
 	l.Info("will stop instance")
 	client := host.Client
 	reqState := api.InstanceStatePut{
@@ -56,7 +58,7 @@ func (s *ShoesLXDMultiServer) DeleteInstance(ctx context.Context, req *pb.Delete
 		return nil, status.Errorf(codes.Internal, "failed to wait deleting instance: %+v", err)
 	}
 
-	l.Info("Success DeleteInstance", "host", host.HostConfig.LxdHost)
+	l.Info("Success DeleteInstance")
 
 	return &pb.DeleteInstanceResponse{}, nil
 }

--- a/server/pkg/api/server_host.go
+++ b/server/pkg/api/server_host.go
@@ -18,13 +18,13 @@ var (
 )
 
 // isExistInstance search created instance in same name
-func (s *ShoesLXDMultiServer) isExistInstance(targetLXDHosts []lxdclient.LXDHost, instanceName string, logger *slog.Logger) (*lxdclient.LXDHost, error) {
+func (s *ShoesLXDMultiServer) isExistInstance(targetLXDHosts []*lxdclient.LXDHost, instanceName string, logger *slog.Logger) (*lxdclient.LXDHost, error) {
 	eg := errgroup.Group{}
 	var foundHost *lxdclient.LXDHost
 	foundHost = nil
 
 	for _, host := range targetLXDHosts {
-		func(host lxdclient.LXDHost) {
+		func(host *lxdclient.LXDHost) {
 			eg.Go(func() error {
 				l := logger.With("host", host.HostConfig.LxdHost)
 				err := isExistInstanceWithTimeout(host, instanceName)
@@ -42,7 +42,7 @@ func (s *ShoesLXDMultiServer) isExistInstance(targetLXDHosts []lxdclient.LXDHost
 					}
 				}
 
-				foundHost = &host
+				foundHost = host
 				return nil
 			})
 		}(host)
@@ -63,7 +63,7 @@ var (
 	ErrTimeoutGetInstance = fmt.Errorf("timeout of GetInstance")
 )
 
-func isExistInstanceWithTimeout(targetLXDHost lxdclient.LXDHost, instanceName string) error {
+func isExistInstanceWithTimeout(targetLXDHost *lxdclient.LXDHost, instanceName string) error {
 	errCh := make(chan error, 1)
 	go func() {
 		_, _, err := targetLXDHost.Client.GetInstance(instanceName)

--- a/server/pkg/lxdclient/resource.go
+++ b/server/pkg/lxdclient/resource.go
@@ -86,6 +86,9 @@ func GetResourceFromLXD(ctx context.Context, hostConfig config.HostConfig, logge
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get resource from lxd: %w", err)
 	}
+
+	client.WithContext(context.Background())
+
 	return r, hostname, nil
 }
 
@@ -122,6 +125,8 @@ func GetResourceFromLXDWithClient(ctx context.Context, client lxd.InstanceServer
 		CPUUsed:     cpuUsed,
 		MemoryUsed:  memoryUsed,
 	}
+
+	c.WithContext(context.Background())
 
 	return &r, hostname, nil
 }

--- a/server/pkg/resourcecache/resource_cache.go
+++ b/server/pkg/resourcecache/resource_cache.go
@@ -33,7 +33,7 @@ func reloadLXDHostResourceCache(ctx context.Context, hcs []config.HostConfig) er
 
 	for _, host := range hosts {
 		_l := l.With("host", host.HostConfig.LxdHost)
-		if err := setLXDHostResourceCache(ctx, &host, _l); err != nil {
+		if err := setLXDHostResourceCache(ctx, host, _l); err != nil {
 			_l.Warn("failed to set lxd host resource cache", "err", err.Error())
 			continue
 		}


### PR DESCRIPTION
This change introduces an APICallMutex.
This is necessary because lxd.Protocol internally holds a context.Context, causing request conflicts.

While caching of ConnectLXD also contributes to this issue, this modification is being made as a workaround for now.