### PR TITLE
fix pool agent metric value

### DIFF
--- a/pool-agent/cmd/agent.go
+++ b/pool-agent/cmd/agent.go
@@ -329,7 +329,7 @@ func (a *Agent) collectMetrics() error {
 	}
 	lxdInstances.Reset()
 	for _, i := range s {
-		lxdInstances.WithLabelValues(i.Status, i.Config[configKeyResourceType], i.Config[configKeyImageAlias], i.Name, i.Config[configKeyRunnerName]).Inc()
+		lxdInstances.WithLabelValues(i.Config[configKeyResourceType], i.Config[configKeyImageAlias], i.Name, i.Config[configKeyRunnerName]).Set(float64(containerStateFromString(i.Status)))
 	}
 	return nil
 }

--- a/pool-agent/cmd/metrics.go
+++ b/pool-agent/cmd/metrics.go
@@ -4,6 +4,45 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+type containerState float64
+
+const (
+	containerStateStopped containerState = iota
+	containerStateRunning
+	containerStateFreezing
+	containerStateFrozen
+)
+
+func (s containerState) String() string {
+	switch s {
+	case containerStateStopped:
+		return "Stopped"
+	case containerStateRunning:
+		return "Running"
+	case containerStateFreezing:
+		return "Freezing"
+	case containerStateFrozen:
+		return "Frozen"
+	default:
+		return "Unknown"
+	}
+}
+
+func containerStateFromString(s string) containerState {
+	switch s {
+	case "Stopped":
+		return containerStateStopped
+	case "Running":
+		return containerStateRunning
+	case "Freezing":
+		return containerStateFreezing
+	case "Frozen":
+		return containerStateFrozen
+	default:
+		return containerStateStopped
+	}
+}
+
 var (
 	configuredInstancesCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -17,10 +56,10 @@ var (
 	lxdInstances = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name:      "instances",
-			Help:      "LXD instances",
+			Help:      "LXD instances. values are enumarated as 0:Stopped, 1:Running, 2:Freezing, 3:Frozen",
 			Subsystem: "lxd",
 			Namespace: "pool_agent",
 		},
-		[]string{"status", "flavor", "image_alias", "container_name", "runner_name"},
+		[]string{"flavor", "image_alias", "container_name", "runner_name"},
 	)
 )


### PR DESCRIPTION
Change a pool-gent metric values to enumerated container status for tracing container status in time series.

## Summary (Generated)
This pull request to `pool-agent` includes changes to improve the collection and representation of LXD instance metrics. The most important changes include modifying the way instance statuses are handled and displayed, and updating the associated Prometheus metrics.

Improvements to metrics collection:

* [`pool-agent/cmd/agent.go`](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dL332-R332): Changed `lxdInstances.WithLabelValues` to set the status as a float value using `containerStateFromString` instead of incrementing a counter.

Enhancements to metrics representation:

* [`pool-agent/cmd/metrics.go`](diffhunk://#diff-88863f11731917e814622a55c0e654dd94b2843560987f519fe65923f71db89cR7-R45): Added a `containerState` type and constants to represent different container states numerically. Implemented `String` and `containerStateFromString` methods to convert between string and numeric representations of container states.
* [`pool-agent/cmd/metrics.go`](diffhunk://#diff-88863f11731917e814622a55c0e654dd94b2843560987f519fe65923f71db89cL20-R63): Updated the `lxdInstances` help description to include the enumeration of container states. Removed the `status` label from the `lxdInstances` metric.