### PR TITLE
Add runner_status in metrics label

### DIFF
--- a/pool-agent/cmd/metrics.go
+++ b/pool-agent/cmd/metrics.go
@@ -21,6 +21,6 @@ var (
 			Subsystem: "lxd",
 			Namespace: "pool_agent",
 		},
-		[]string{"status", "flavor", "image_alias", "container_name", "runner_name"},
+		[]string{"status", "flavor", "image_alias", "container_name", "runner_name", "runner_status"},
 	)
 )


### PR DESCRIPTION
This pull request introduces enhancements to the `pool-agent` to improve metrics collection and runner status tracking. The key changes include adding runner status constants, implementing a new method to determine the job status of instances, and updating metrics to include runner status as a label.

### Enhancements to metrics collection:
* Updated the `lxdInstances` metrics to include a new label, `runner_status`, which tracks the status of the runner (e.g., "Creating," "Listening," "Running," or "Finished"). (`pool-agent/cmd/metrics.go`, [pool-agent/cmd/metrics.goL24-R24](diffhunk://#diff-88863f11731917e814622a55c0e654dd94b2843560987f519fe65923f71db89cL24-R24))
* Modified the `collectMetrics` method to use the new `getJobStatus` method for determining the runner status of each instance and incorporating it into the metrics. (`pool-agent/cmd/agent.go`, [pool-agent/cmd/agent.goL335-R345](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dL335-R345))

### Runner status tracking:
* Added a new method, `getJobStatus`, to determine the runner's status by analyzing the output of a `journalctl` command executed on the instance. This method identifies specific states such as "Listening for Jobs" or "Running job." (`pool-agent/cmd/agent.go`, [pool-agent/cmd/agent.goR371-R440](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dR371-R440))
* Introduced constants for runner statuses (`RunnerStatusCreating`, `RunnerStatusListening`, `RunnerStatusRunning`, `RunnerStatusFinished`) to standardize status representation. (`pool-agent/cmd/agent.go`, [pool-agent/cmd/agent.goR21-R28](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dR21-R28))

### Minor updates:
* Added the `strings` package to support string manipulation in the new `getJobStatus` method. (`pool-agent/cmd/agent.go`, [pool-agent/cmd/agent.goR11](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dR11))