### PR TITLE
Add FEATUREFLAG=count-without-running that compatible as #64

### DIFF
--- a/pool-agent/pkg/featureflag/featureflag.go
+++ b/pool-agent/pkg/featureflag/featureflag.go
@@ -1,0 +1,44 @@
+package featureflag
+
+import (
+	"os"
+	"strings"
+)
+
+// FeatureFlag represents available feature flags
+type FeatureFlag string
+
+const (
+	// CountWithoutRunning disables counting Running instances in pool count
+	CountWithoutRunning FeatureFlag = "count-without-running"
+)
+
+// featureFlags holds the current state of feature flags
+var featureFlags map[FeatureFlag]bool
+
+func init() {
+	LoadFromEnv()
+}
+
+// LoadFromEnv loads feature flags from FEATUREFLAG environment variable
+func LoadFromEnv() {
+	featureFlags = make(map[FeatureFlag]bool)
+
+	flagsEnv := os.Getenv("FEATUREFLAG")
+	if flagsEnv == "" {
+		return
+	}
+
+	flags := strings.Split(flagsEnv, ",")
+	for _, flag := range flags {
+		flag = strings.TrimSpace(flag)
+		if flag != "" {
+			featureFlags[FeatureFlag(flag)] = true
+		}
+	}
+}
+
+// IsEnabled checks if a feature flag is enabled
+func IsEnabled(flag FeatureFlag) bool {
+	return featureFlags[flag]
+}


### PR DESCRIPTION
This pull request introduces a feature flag system to the `pool-agent` module, enabling dynamic configuration of certain behaviors. The most significant change is the addition of logic to exclude `Running` instances from the pool count when the `count-without-running` feature flag is enabled.

### Feature Flag System:

* **New feature flag implementation**: Added a `featureflag` package to manage feature flags, including loading flags from the `FEATUREFLAG` environment variable and checking their enabled state. (`pool-agent/pkg/featureflag/featureflag.go`)

### Behavior Changes in Instance Counting:

* **Conditional logic based on feature flag**: Updated the `isPooledInstance` function in `agent.go` to exclude `Running` instances from the pool count when the `count-without-running` feature flag is enabled. Default behavior remains unchanged otherwise. (`pool-agent/cmd/agent.go`)

### Codebase Updates:

* **Import statement modification**: Added the `featureflag` package to the imports in `agent.go`. (`pool-agent/cmd/agent.go`)