### PR TITLE
Fix a target name of console log

### DIFF
--- a/pool-agent/cmd/agent.go
+++ b/pool-agent/cmd/agent.go
@@ -399,7 +399,7 @@ func (a *Agent) getJobStatus(logger *slog.Logger, instance api.Instance) string 
 		return RunnerStatusCreating
 	}
 
-	consoleLogPath := filepath.Join(a.LxdDir, "myshoes-runner-"+runnerName, "console.log")
+	consoleLogPath := filepath.Join(a.LxdDir, instance.Name, "console.log")
 
 	file, err := os.Open(consoleLogPath)
 	if err != nil {


### PR DESCRIPTION
This pull request updates the `getJobStatus` method in the `pool-agent/cmd/agent.go` file to improve how the console log path is constructed, ensuring it uses the `instance.Name` instead of a hardcoded string.

Key change:

* [`pool-agent/cmd/agent.go`](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dL402-R402): Updated the `consoleLogPath` variable to dynamically use `instance.Name`, making the code more flexible and reducing dependency on hardcoded values.