### PR TITLE
Add configured_github_repository to metrics

### DIFF
--- a/pool-agent/cmd/metrics.go
+++ b/pool-agent/cmd/metrics.go
@@ -21,6 +21,6 @@ var (
 			Subsystem: "lxd",
 			Namespace: "pool_agent",
 		},
-		[]string{"status", "flavor", "image_alias", "container_name", "runner_name", "runner_status"},
+		[]string{"status", "flavor", "image_alias", "container_name", "runner_name", "runner_status", "configured_github_repository"},
 	)
 )


### PR DESCRIPTION
This pull request enhances the `pool-agent` by adding functionality to track the GitHub repository associated with jobs running in LXD instances. The changes primarily involve extending metrics collection and modifying the `getJobStatus` method to extract and return the repository information.

### Enhancements to metrics collection:

* [`pool-agent/cmd/metrics.go`](diffhunk://#diff-88863f11731917e814622a55c0e654dd94b2843560987f519fe65923f71db89cL24-R24): Updated the `lxdInstances` metric to include a new label, `configured_github_repository`, for tracking the GitHub repository associated with each job.
* [`pool-agent/cmd/agent.go`](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dL363-R364): Modified `collectMetrics` to pass the extracted GitHub repository to the `lxdInstances.WithLabelValues` method.

### Changes to job status extraction:

* [`pool-agent/cmd/agent.go`](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dL390-R414): Updated the `getJobStatus` method to return a tuple containing both the runner status and the GitHub repository. Added logic to parse the repository from console log lines containing "Configuring ... @ https://github.com/...". [[1]](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dL390-R414) [[2]](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dL426-R432) [[3]](diffhunk://#diff-5196571db414ccfd5f9597359658a2343b86aaa70bea24b9e4c9370ed312e73dR446-R465)