### PR TITLE
perf: locate instance from in-memory cache before querying all hosts on delete

### DIFF
--- a/server/pkg/api/server_host.go
+++ b/server/pkg/api/server_host.go
@@ -19,8 +19,45 @@ var (
 	ErrInstanceIsNotFound = fmt.Errorf("instance is not found")
 )
 
-// isExistInstance search created instance in same name
+// isExistInstance search created instance in same name.
+// It first tries to locate the host from the in-memory resource cache and confirms the
+// result with a single API call, instead of querying every target host. When the cache
+// does not know the instance (cache miss or a stale entry), it falls back to querying all
+// target hosts.
 func (s *ShoesLXDMultiServer) isExistInstance(targetLXDHosts []*lxdclient.LXDHost, instanceName string, logger *slog.Logger) (*lxdclient.LXDHost, error) {
+	if host := findInstanceHostFromCache(targetLXDHosts, instanceName); host != nil {
+		// The cache can be stale, so confirm the instance really exists on the host with
+		// a single API call before trusting it.
+		if err := isExistInstanceWithTimeout(host, instanceName); err == nil {
+			return host, nil
+		}
+		logger.With("host", host.HostConfig.LxdHost).Debug("instance found in cache but not confirmed on host, fall back to querying all hosts", "instanceName", instanceName)
+	}
+
+	return isExistInstanceInHosts(targetLXDHosts, instanceName, logger)
+}
+
+// findInstanceHostFromCache returns the host that has the instance according to the
+// in-memory resource cache. It returns nil when no cached host has the instance, in which
+// case the caller should fall back to querying the hosts directly.
+func findInstanceHostFromCache(targetLXDHosts []*lxdclient.LXDHost, instanceName string) *lxdclient.LXDHost {
+	for _, host := range targetLXDHosts {
+		status, err := lxdclient.GetStatusCache(host.HostConfig.LxdHost)
+		if err != nil {
+			// cache miss for this host, try the next one.
+			continue
+		}
+		for _, instance := range status.Resource.Instances {
+			if instance.Name == instanceName {
+				return host
+			}
+		}
+	}
+	return nil
+}
+
+// isExistInstanceInHosts searches the instance by querying all target hosts.
+func isExistInstanceInHosts(targetLXDHosts []*lxdclient.LXDHost, instanceName string, logger *slog.Logger) (*lxdclient.LXDHost, error) {
 	eg := errgroup.Group{}
 	var foundHost *lxdclient.LXDHost
 	foundHost = nil

--- a/server/pkg/api/server_host_test.go
+++ b/server/pkg/api/server_host_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/lxc/lxd/shared/api"
+
+	"github.com/whywaita/shoes-lxd-multi/server/pkg/config"
+	"github.com/whywaita/shoes-lxd-multi/server/pkg/lxdclient"
+)
+
+func TestFindInstanceHostFromCache(t *testing.T) {
+	hostA := &lxdclient.LXDHost{HostConfig: config.HostConfig{LxdHost: "test-host-a"}}
+	hostB := &lxdclient.LXDHost{HostConfig: config.HostConfig{LxdHost: "test-host-b"}}
+	hostNoCache := &lxdclient.LXDHost{HostConfig: config.HostConfig{LxdHost: "test-host-no-cache"}}
+
+	if err := lxdclient.SetStatusCache(hostA.HostConfig.LxdHost, lxdclient.LXDStatus{
+		Resource: lxdclient.Resource{Instances: []api.Instance{{Name: "instance-on-a"}}},
+	}); err != nil {
+		t.Fatalf("failed to set status cache for host a: %+v", err)
+	}
+	if err := lxdclient.SetStatusCache(hostB.HostConfig.LxdHost, lxdclient.LXDStatus{
+		Resource: lxdclient.Resource{Instances: []api.Instance{{Name: "instance-on-b-1"}, {Name: "instance-on-b-2"}}},
+	}); err != nil {
+		t.Fatalf("failed to set status cache for host b: %+v", err)
+	}
+
+	targets := []*lxdclient.LXDHost{hostNoCache, hostA, hostB}
+
+	tests := []struct {
+		name         string
+		instanceName string
+		want         *lxdclient.LXDHost
+	}{
+		{name: "found on host a", instanceName: "instance-on-a", want: hostA},
+		{name: "found on host b (second entry)", instanceName: "instance-on-b-2", want: hostB},
+		{name: "not cached anywhere", instanceName: "instance-unknown", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findInstanceHostFromCache(targets, tt.instanceName)
+			if got != tt.want {
+				t.Errorf("findInstanceHostFromCache(%q) = %v, want %v", tt.instanceName, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFindInstanceHostFromCacheSkipsHostWithoutCache ensures a cache miss for a host does
+// not stop the lookup from checking the remaining hosts.
+func TestFindInstanceHostFromCacheSkipsHostWithoutCache(t *testing.T) {
+	hostMiss := &lxdclient.LXDHost{HostConfig: config.HostConfig{LxdHost: "test-skip-miss"}}
+	hostHit := &lxdclient.LXDHost{HostConfig: config.HostConfig{LxdHost: "test-skip-hit"}}
+
+	if err := lxdclient.SetStatusCache(hostHit.HostConfig.LxdHost, lxdclient.LXDStatus{
+		Resource: lxdclient.Resource{Instances: []api.Instance{{Name: "wanted"}}},
+	}); err != nil {
+		t.Fatalf("failed to set status cache: %+v", err)
+	}
+
+	got := findInstanceHostFromCache([]*lxdclient.LXDHost{hostMiss, hostHit}, "wanted")
+	if got != hostHit {
+		t.Errorf("findInstanceHostFromCache() = %v, want %v", got, hostHit)
+	}
+}


### PR DESCRIPTION
## Motivation

When the server deletes an instance, `DeleteInstance` (`server/pkg/api/server_delete_instance.go`) locates the target host by calling `isExistInstance`, which previously queried **every configured target host concurrently** via a live `GetInstance` API call to find which host holds the instance.

Under high delete concurrency this fans out to `(concurrent deletes) x (number of hosts)` LXD API calls just to *locate* each instance, putting heavy load on all hosts.

The server already maintains an in-memory resource cache (`server/pkg/lxdclient/resource_cache.go`, refreshed periodically by the resource-cache ticker and the metrics scrape) whose `LXDStatus.Resource.Instances` holds the per-host instance list. This cache was previously consumed only by scheduling/pool/metrics code, **not** by the delete/locate path.

## What this PR does

`isExistInstance` now consults that cache first to locate the host:

- **Cache hit** → confirm the instance really exists on that host with a **single** `GetInstance` call (the cache can be stale), then return it.
- **Cache miss / stale entry / unconfirmed** → fall back to the existing full scan, extracted verbatim as `isExistInstanceInHosts`.

This removes the all-hosts fan-out in the common case. Behavior on a cache miss is **identical** to before, so there is no regression.

## Scope

- Touches only `server/pkg/api/server_host.go` (+ new test `server/pkg/api/server_host_test.go`).
- Does **not** change `DeleteInstance`'s mutex/context handling (separate concern).

## Testing

`gofmt`, `go vet ./...`, `go build ./...`, `go test ./pkg/api/...` all pass. New unit tests cover `findInstanceHostFromCache`: hit on first cached host, hit on a later entry of another host, no match anywhere, and skipping a host with no cache entry.